### PR TITLE
child_processに関連するオブジェクトcpやexecSync関数を消去して、パスだけ表示

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 'use strict';
 const http = require('http');
-const cp = require('child_process');
 const server = http.createServer((req, res) => {
   const path = req.url;
-  res.end(cp.execSync('echo ' + path));
+  res.end(path);
 });
 const port = 8000;
 server.listen(port, () => {


### PR DESCRIPTION
マージ不要です。