### PR TITLE
Fix OSCommandInjection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 'use strict';
 const http = require('http');
-const cp = require('child_process');
 const server = http.createServer((req, res) => {
   const path = req.url;
-  res.end(cp.execSync('echo ' + path));
+  res.end(path);
 });
 const port = 8000;
 server.listen(port, () => {


### PR DESCRIPTION
パスに続けて`;コマンド`と打つことで、そのコマンドの実行が可能でした。
=> execSync関数の使用を辞め、コマンドの実行を不可能にしました。